### PR TITLE
check resource group exists before creation

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,7 +16,7 @@ namespace: molecule
 
 name: driver
 
-version: 0.2.0
+version: 0.3.0
 
 readme: README.md
 

--- a/playbooks/azure/tasks/create_instance.yml
+++ b/playbooks/azure/tasks/create_instance.yml
@@ -22,11 +22,18 @@
 # https://docs.microsoft.com/en-us/azure/developer/ansible/vm-configure-windows?tabs=ansible
 # https://docs.microsoft.com/en-us/azure/developer/ansible/vm-configure?tabs=ansible
 
+- name: Get info for resource group
+  azure.azcollection.azure_rm_resourcegroup_info:
+    name:  "{{ item.resourcegroup_name |
+      default (azure_rm_resourcegroup_name_default) }}"
+  register: _
+
 - name: Create resource group
   azure.azcollection.azure_rm_resourcegroup:
     name: "{{ item.resourcegroup_name |
       default (azure_rm_resourcegroup_name_default) }}"
     location: "{{ item.location }}"
+  when: not (_.resourcegroups | length)
 
 - name: Create virtual network for molecule
   azure.azcollection.azure_rm_virtualnetwork:


### PR DESCRIPTION
this PR will add functionality to check if resource group exists before creating it.

Resource group and resources in that group can be in different locations. This PR will fix issue when molecule create failed if resource group existed in different region, it cannot be moved and molecule fails. 
