### PR TITLE
Bump Makefile version to 0.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # You should have received a copy of the GNU General Public License along with this program.
 # If not, see <https://www.gnu.org/licenses/>.
 
-VERSION=0.2.0
+VERSION=0.3.0
 
 .DEFAULT_GOAL:=help
 


### PR DESCRIPTION
This PR fixes the mismatch between galaxy version `0.3.0` and Makefile version `0.2.0`

Signed-off-by: Gloria Ciavarrini <gciavarrini@redhat.com>