### PR TITLE
never regenerate ssh key, if it is present

### DIFF
--- a/playbooks/azure_create.yml
+++ b/playbooks/azure_create.yml
@@ -50,6 +50,7 @@
     - name: Generate an OpenSSH keypair
       community.crypto.openssh_keypair:
         path: "{{ ( ssh_private_key_path | default(ssh_private_key_path_default) ) }}"
+        regenerate: never
 
     - name: Create instances
       ansible.builtin.include_tasks: azure/tasks/create_instance.yml


### PR DESCRIPTION
See documentation 
https://docs.ansible.com/ansible/latest/collections/community/crypto/openssh_keypair_module.html#parameter-regenerate

I would like never regenerate a ssh key it exists. I've faced this issue. SSH keys are sensitive and people might not have backup.