### PR TITLE
set vm state to started when creating

### DIFF
--- a/playbooks/azure/tasks/create_instance.yml
+++ b/playbooks/azure/tasks/create_instance.yml
@@ -77,7 +77,7 @@
     image: "{{ item.marketplace_image }}"
     license_type: "{{ item.license_type | default(omit) }}"
     plan: "{{ item.plan | default(omit) }}"
-    state: present
+    state: started
   register: server
   # with_items: "{{ molecule_yml.platforms }}"
   # TODO create async job in instance_create.yml and wait for all jobs to finish in create.yaml


### PR DESCRIPTION
small fix, otherwise VMs do not get public IP if run `molecule create` from deallocated state